### PR TITLE
Revert "Update hashicorp/setup-terraform action to v3"

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -21,7 +21,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y nodejs
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v2
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 


### PR DESCRIPTION
Reverts damoun/tf-talos#5

Revert to v2 because Github Actions runner still run Node16 and v3 require Node20.